### PR TITLE
Make project useable by downstream CMake projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,6 @@ if (MSVC)
     add_definitions(-D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE)
 endif(MSVC)
 
-include_directories(${Skyr_SOURCE_DIR}/src ${Skyr_SOURCE_DIR}/include)
-
 add_subdirectory(src)
 
 # Testing

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,13 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
     endif()
 endif()
 
+target_include_directories(skyr-url
+    PUBLIC
+        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${Skyr_SOURCE_DIR}/include>
+    PRIVATE
+        ${Skyr_SOURCE_DIR}/src)
+
 if(${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
 	if (Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS)
 	    target_link_libraries(skyr-url "stdc++fs")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,8 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
     endif()
 endif()
 
+add_library(Skyr::skyr-url ALIAS skyr-url)
+
 target_include_directories(skyr-url
     PUBLIC
         $<INSTALL_INTERFACE:include>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,9 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
     endif()
 endif()
 
+set_target_properties(skyr-url PROPERTIES
+        POSITION_INDEPENDENT_CODE ON)
+
 add_library(Skyr::skyr-url ALIAS skyr-url)
 
 target_include_directories(skyr-url


### PR DESCRIPTION
This PR makes three independent changes to the build set-up that make it possible (in my setup) to use this project through `add_subdirectory` and modern CMake targets. I am trying to implement best practices as advocated [here](https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/) and [here](https://rix0r.nl/blog/2015/08/13/cmake-guide/), among others.

More precisely, I want to include the project like this:

```cmake
add_subdirectory("${Skyr_ROOT_DIR}" skyr-url)
target_link_libraries(downstream-library
    PUBLIC Skyr::skyr-url)
```

The three commits solve the following three problems:
* Only the target `skyr-url` exist, but is not aliased. It is common practice to alias the public targets of a project in a namespace.
* The include directories are set directory wide, so they work to compile the examples, but downstream projects need to set them manually. By making them *target* properties, downstream projects do not need to do anything -- CMake sets the include flags automatically.
* It is currently not possible to link the generated `libskyr-url.a` into a shared library because it is not position independent (GCC's `-fPIC`). CMake has a platform/compiler-independent mechanism to achieve that.