### PR TITLE
Fixed header location for catch.hpp

### DIFF
--- a/tests/domain/domain_tests.cpp
+++ b/tests/domain/domain_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <string>
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/domain/domain.hpp>
 #include <skyr/domain/errors.hpp>
 

--- a/tests/domain/idna_table_tests.cpp
+++ b/tests/domain/idna_table_tests.cpp
@@ -4,7 +4,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/v1/domain/idna.hpp>
 
 TEST_CASE("IDNA character values", "[idna]") {
@@ -15,7 +15,7 @@ TEST_CASE("IDNA character values", "[idna]") {
           param{0x002d, skyr::domain::idna_status::valid},
           param{0x10fffd, skyr::domain::idna_status::disallowed},
           param{0x10ffff, skyr::domain::idna_status::disallowed});
-  
+
   SECTION("code_point_set") {
     const auto [value, mapped] = code_point;
     REQUIRE(mapped == skyr::domain::map_idna_status(value));

--- a/tests/domain/punycode_tests.cpp
+++ b/tests/domain/punycode_tests.cpp
@@ -4,7 +4,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <string>
 #include <skyr/domain/punycode.hpp>
 

--- a/tests/filesystem/filesystem_path_tests.cpp
+++ b/tests/filesystem/filesystem_path_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/url.hpp>
 #include <skyr/filesystem/path.hpp>
 

--- a/tests/json/json_query_tests.cpp
+++ b/tests/json/json_query_tests.cpp
@@ -5,7 +5,7 @@
 
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <vector>
 #include <skyr/json/json.hpp>
 

--- a/tests/network/ipv4_address_tests.cpp
+++ b/tests/network/ipv4_address_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/network/ipv4_address.hpp>
 
 TEST_CASE("ipv4 addresses", "[ipv4]") {

--- a/tests/network/ipv6_address_tests.cpp
+++ b/tests/network/ipv6_address_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/network/ipv6_address.hpp>
 
 TEST_CASE("ipv6_address_tests", "[ipv6]") {

--- a/tests/percent_encoding/percent_decoding_tests.cpp
+++ b/tests/percent_encoding/percent_decoding_tests.cpp
@@ -4,7 +4,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 #include <skyr/v1/percent_encoding/percent_decode_range.hpp>

--- a/tests/percent_encoding/percent_encoding_tests.cpp
+++ b/tests/percent_encoding/percent_encoding_tests.cpp
@@ -4,7 +4,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 #include <skyr/v1/percent_encoding/percent_encode_range.hpp>

--- a/tests/unicode/byte_conversion_tests.cpp
+++ b/tests/unicode/byte_conversion_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <string>
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/v1/unicode/details/to_u8.hpp>
 
 TEST_CASE("weird_01", "byte_conversion_tests") {

--- a/tests/url/query_parameter_range_tests.cpp
+++ b/tests/url/query_parameter_range_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <string_view>
 #include <skyr/query/query_parameter_range.hpp>
 

--- a/tests/url/string_tests.cpp
+++ b/tests/url/string_tests.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <memory>
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/v1/ranges/string_element_range.hpp>
 
 using namespace std::string_literals;

--- a/tests/url/url_literal_tests.cpp
+++ b/tests/url/url_literal_tests.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <memory>
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/url.hpp>
 
 using namespace skyr::literals;

--- a/tests/url/url_parse_tests.cpp
+++ b/tests/url/url_parse_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/core/parse.hpp>
 #include <skyr/core/serialize.hpp>
 

--- a/tests/url/url_search_parameters_tests.cpp
+++ b/tests/url/url_search_parameters_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/v1/url.hpp>
 #include <skyr/v1/url_search_parameters.hpp>
 

--- a/tests/url/url_serialize_tests.cpp
+++ b/tests/url/url_serialize_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/core/url_record.hpp>
 #include <skyr/core/parse.hpp>
 #include <skyr/core/serialize.hpp>

--- a/tests/url/url_setter_tests.cpp
+++ b/tests/url/url_setter_tests.cpp
@@ -4,13 +4,13 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/url.hpp>
 
 TEST_CASE("url_setter_tests", "[url]") {
   SECTION("test_href_1") {
     auto instance = skyr::url{};
-  
+
     auto ec = instance.set_href("http://example.com/");
     REQUIRE_FALSE(ec);
     CHECK("http:" == instance.protocol());
@@ -20,7 +20,7 @@ TEST_CASE("url_setter_tests", "[url]") {
 
   SECTION("test_href_2") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_href("https://cpp-netlib.org/?a=b#fragment");
     REQUIRE_FALSE(ec);
     CHECK("https:" == instance.protocol());
@@ -29,10 +29,10 @@ TEST_CASE("url_setter_tests", "[url]") {
     CHECK("?a=b" == instance.search());
     CHECK("#fragment" == instance.hash());
   }
-  
+
   SECTION("test_href_parse_error") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_href("Ceci n'est pas un URL");
     REQUIRE(ec);
     CHECK("http:" == instance.protocol());
@@ -41,180 +41,180 @@ TEST_CASE("url_setter_tests", "[url]") {
     CHECK("" == instance.search());
     CHECK("" == instance.hash());
   }
-  
+
   SECTION("test_protocol_special_to_special") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_protocol("ws");
     REQUIRE_FALSE(ec);
     CHECK("ws://example.com/" == instance.href());
     CHECK("ws:" == instance.protocol());
   }
-  
+
   SECTION("test_protocol_special_to_non_special") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_protocol("non-special");
     REQUIRE(ec);
     CHECK("http://example.com/" == instance.href());
   }
-  
+
   SECTION("test_protocol_non_special_to_special") {
     auto instance = skyr::url{"non-special://example.com/"};
-  
+
     auto ec = instance.set_protocol("http");
     REQUIRE(ec);
     CHECK("non-special://example.com/" == instance.href());
   }
-  
+
   SECTION("test_protocol_has_port_to_file") {
     auto instance = skyr::url{"http://example.com:8080/"};
-  
+
     auto ec = instance.set_protocol("file");
     REQUIRE(ec);
     CHECK("http://example.com:8080/" == instance.href());
   }
-  
+
   SECTION("test_protocol_has_no_port_to_file") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_protocol("file");
     REQUIRE_FALSE(ec);
     CHECK("file://example.com/" == instance.href());
     CHECK("file:" == instance.protocol());
   }
-  
+
   SECTION("test_username") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_username("user");
     REQUIRE_FALSE(ec);
     CHECK("http://user@example.com/" == instance.href());
     CHECK("user" == instance.username());
   }
-  
+
   SECTION("test_username_pct_encoded") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto result = instance.set_username("us er");
     REQUIRE_FALSE(result);
     CHECK("http://us%20er@example.com/" == instance.href());
     CHECK("us%20er" == instance.username());
   }
-  
+
   SECTION("test_username_file_scheme") {
     auto instance = skyr::url{"file://example.com/"};
-  
+
     auto ec = instance.set_username("user");
     REQUIRE(ec);
     CHECK("file://example.com/" == instance.href());
   }
-  
+
   SECTION("test_password") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_password("pass");
     REQUIRE_FALSE(ec);
     CHECK("http://:pass@example.com/" == instance.href());
     CHECK("pass" == instance.password());
   }
-  
+
   SECTION("test_password_pct_encoded") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_password("pa ss");
     REQUIRE_FALSE(ec);
     CHECK("http://:pa%20ss@example.com/" == instance.href());
     CHECK("pa%20ss" == instance.password());
   }
-  
+
   SECTION("test_password_file_scheme") {
     auto instance = skyr::url{"file://example.com/"};
-  
+
     auto ec = instance.set_password("pass");
     REQUIRE(ec);
     CHECK("file://example.com/" == instance.href());
   }
-  
+
   SECTION("test_host_http") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_host("elpmaxe.com");
     REQUIRE_FALSE(ec);
     CHECK("http://elpmaxe.com/" == instance.href());
     CHECK("elpmaxe.com" == instance.host());
   }
-  
+
   SECTION("test_host_with_port_number") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_host("elpmaxe.com:8080");
     REQUIRE_FALSE(ec);
     CHECK("http://elpmaxe.com:8080/" == instance.href());
     CHECK("elpmaxe.com:8080" == instance.host());
     CHECK("elpmaxe.com" == instance.hostname());
   }
-  
+
   SECTION("test_host_file_set_non_empty_host") {
     auto instance = skyr::url{"file:///path/to/helicon/"};
-  
+
     auto ec = instance.set_host("example.com");
     REQUIRE_FALSE(ec);
     CHECK("file://example.com/path/to/helicon/" == instance.href());
     CHECK("example.com" == instance.host());
     CHECK("/path/to/helicon/" == instance.pathname());
   }
-  
+
   SECTION("test_host_file_with_port_number") {
     auto instance = skyr::url{"file:///path/to/helicon/"};
-  
+
     auto ec = instance.set_host("example.com:8080");
     REQUIRE(ec);
   }
-  
+
   SECTION("test_host_file_set_empty_host") {
     auto instance = skyr::url{"file://example.com/path/to/helicon/"};
-  
+
     auto ec = instance.set_host("");
     REQUIRE_FALSE(ec);
     CHECK("file:///path/to/helicon/" == instance.href());
     CHECK("" == instance.host());
     CHECK("/path/to/helicon/" == instance.pathname());
   }
-  
-  
+
+
   SECTION("test_hostname_http") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_hostname("elpmaxe.com");
     REQUIRE_FALSE(ec);
     CHECK("http://elpmaxe.com/" == instance.href());
     CHECK("elpmaxe.com" == instance.hostname());
   }
-  
+
   SECTION("test_hostname_with_port_number") {
     auto instance = skyr::url{"http://example.com:8080/"};
-  
+
     auto ec = instance.set_hostname("elpmaxe.com");
     REQUIRE_FALSE(ec);
     CHECK("http://elpmaxe.com:8080/" == instance.href());
     CHECK("elpmaxe.com:8080" == instance.host());
     CHECK("elpmaxe.com" == instance.hostname());
   }
-  
+
   SECTION("test_hostname_file_set_non_empty_host") {
     auto instance = skyr::url{"file:///path/to/helicon/"};
-  
+
     auto ec = instance.set_hostname("example.com");
     REQUIRE_FALSE(ec);
     CHECK("file://example.com/path/to/helicon/" == instance.href());
     CHECK("example.com" == instance.hostname());
     CHECK("/path/to/helicon/" == instance.pathname());
   }
-  
+
   SECTION("test_hostname_file_set_empty_host") {
     auto instance = skyr::url{"file://example.com/path/to/helicon/"};
-  
+
     auto ec = instance.set_hostname("");
     REQUIRE_FALSE(ec);
     CHECK("file:///path/to/helicon/" == instance.href());
@@ -224,71 +224,71 @@ TEST_CASE("url_setter_tests", "[url]") {
 
   SECTION("test_port_no_port") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_port("8080");
     REQUIRE_FALSE(ec);
     CHECK("http://example.com:8080/" == instance.href());
   }
-  
+
   SECTION("test_port_existing_port") {
     auto instance = skyr::url{"http://example.com:80/"};
-  
+
     auto ec = instance.set_port("8080");
     REQUIRE_FALSE(ec);
     CHECK("http://example.com:8080/" == instance.href());
   }
-  
+
   SECTION("test_port_existing_port_no_port_1") {
     auto instance = skyr::url{"http://example.com:80/"};
-  
+
     auto ec = instance.set_port("");
     REQUIRE_FALSE(ec);
     CHECK("http://example.com/" == instance.href());
   }
-  
+
   SECTION("test_port_invalid_port_1") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_port("Ceci n'est pas un port");
     REQUIRE_FALSE(ec);
     CHECK("http://example.com/" == instance.href());
   }
-  
+
   SECTION("test_port_invalid_port_2") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_port("1234567890");
     REQUIRE(ec);
     CHECK("http://example.com/" == instance.href());
   }
-  
+
   SECTION("test_port_invalid_port_3") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_port("8080C");
     REQUIRE_FALSE(ec);
     CHECK("http://example.com:8080/" == instance.href());
   }
-  
+
   SECTION("test_port_invalid_port_4") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_port("-1");
     REQUIRE_FALSE(ec);
     CHECK("http://example.com/" == instance.href());
   }
-  
+
   SECTION("test_port_existing_port_no_port_2") {
     auto instance = skyr::url{"http://example.com:/"};
-  
+
     auto ec = instance.set_port("");
     REQUIRE_FALSE(ec);
     CHECK("http://example.com/" == instance.href());
   }
-  
+
   SECTION("test_port_no_port_int") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_port(8080);
     REQUIRE_FALSE(ec);
     CHECK("http://example.com:8080/" == instance.href());
@@ -301,66 +301,66 @@ TEST_CASE("url_setter_tests", "[url]") {
     REQUIRE_FALSE(ec);
     CHECK("http://example.com:8080/path" == instance.href());
   }
-  
+
   SECTION("test_pathname_1") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_pathname("/path/to/helicon/");
     REQUIRE_FALSE(ec);
     CHECK("http://example.com/path/to/helicon/" == instance.href());
   }
-  
+
   SECTION("test_pathname_2") {
     auto instance = skyr::url{"http://example.com/path/to/helicon/"};
-  
+
     auto ec = instance.set_pathname("");
     REQUIRE_FALSE(ec);
     CHECK("http://example.com/" == instance.href());
   }
-  
+
   SECTION("test_pathname_3") {
     auto instance = skyr::url{"file:///path/to/helicon/"};
-  
+
     auto ec = instance.set_pathname("");
     REQUIRE_FALSE(ec);
     CHECK("file:///" == instance.href());
   }
-  
+
   SECTION("test_search_1") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_search("?a=b&c=d");
     REQUIRE_FALSE(ec);
     CHECK("http://example.com/?a=b&c=d" == instance.href());
   }
-  
+
   SECTION("test_search_2") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_search("a=b&c=d");
     REQUIRE_FALSE(ec);
     CHECK("http://example.com/?a=b&c=d" == instance.href());
   }
-  
+
   SECTION("test_search_3") {
     auto instance = skyr::url{"http://example.com/#fragment"};
-  
+
     auto ec = instance.set_search("?a=b&c=d");
     REQUIRE_FALSE(ec);
     CHECK("http://example.com/?a=b&c=d#fragment" == instance.href());
   }
-  
+
   SECTION("test_hash_1") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_hash("#fragment");
     REQUIRE_FALSE(ec);
     CHECK("http://example.com/#fragment" == instance.href());
   }
-  
+
   SECTION("test_hash_2") {
     auto instance = skyr::url{"http://example.com/"};
-  
+
     auto ec = instance.set_hash("fragment");
     REQUIRE_FALSE(ec);
     CHECK("http://example.com/#fragment" == instance.href());

--- a/tests/url/url_tests.cpp
+++ b/tests/url/url_tests.cpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <memory>
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/url.hpp>
 
 TEST_CASE("url_tests", "[url]") {

--- a/tests/url/url_tests_with_exceptions.cpp
+++ b/tests/url/url_tests_with_exceptions.cpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <memory>
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/url.hpp>
 
 TEST_CASE("url_tests", "[url]") {

--- a/tests/url/url_vector_tests.cpp
+++ b/tests/url/url_vector_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <vector>
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <skyr/url.hpp>
 
 TEST_CASE("url_vector_tests", "[url]") {


### PR DESCRIPTION
The default install location for Catch2 is TARGETDIR/include/catch2/catch.hpp. Some tests already use this location, i.e. #include <catch2/catch.hpp> but the majority includes just <catch.hpp>.

This PR changes that. It therefore makes the includes more consistent. Tested with Catch2 v2.12.1 (latest as of today).

Fixes #89