### PR TITLE
Add transitive cmake dependencies

### DIFF
--- a/cmake/skyr-url-config.cmake.in
+++ b/cmake/skyr-url-config.cmake.in
@@ -1,3 +1,5 @@
+find_dependency(tl-expected)
+
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/skyr-url-targets.cmake")


### PR DESCRIPTION
Our downstream project was missing the tl-expected dependency, so I added it to the cmake.in for automatic detection.