### PR TITLE
default_port works with protocol values (i.e. scheme + ':')

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,3 +32,5 @@ BreakBeforeBraces: Attach
 SpacesInParentheses: false
 SpaceInEmptyParentheses: false
 SpacesInCStyleCastParentheses: false
+SortIncludes: false
+SortUsingDeclarations: false

--- a/include/skyr/v1/core/schemes.hpp
+++ b/include/skyr/v1/core/schemes.hpp
@@ -46,6 +46,9 @@ inline auto is_special(std::string_view scheme) noexcept {
 /// \param scheme
 /// \returns
 inline auto default_port(std::string_view scheme) noexcept {
+  if (scheme.back() == ':') {
+    scheme.remove_suffix(1);
+  }
   auto it = std::lower_bound(cbegin(details::schemes), cend(details::schemes), scheme, details::scheme_less);
   return ((it != end(details::schemes)) && !(scheme < it->first)) ? it->second : std::nullopt;
 }

--- a/include/skyr/v1/core/schemes.hpp
+++ b/include/skyr/v1/core/schemes.hpp
@@ -32,7 +32,7 @@ constexpr static auto schemes = default_port_list{{
 
 /// \param scheme
 /// \returns
-constexpr inline auto is_special(std::string_view scheme) noexcept {
+inline auto is_special(std::string_view scheme) noexcept {
   constexpr auto less = [] (const auto &special_scheme, auto scheme) {
     return special_scheme.first < scheme;
   };
@@ -47,7 +47,7 @@ constexpr inline auto is_special(std::string_view scheme) noexcept {
 
 /// \param scheme
 /// \returns
-constexpr inline auto default_port(std::string_view scheme) noexcept {
+inline auto default_port(std::string_view scheme) noexcept {
   constexpr auto less = [] (const auto &special_scheme, auto scheme) {
     return special_scheme.first < scheme;
   };

--- a/include/skyr/v1/core/schemes.hpp
+++ b/include/skyr/v1/core/schemes.hpp
@@ -28,29 +28,36 @@ constexpr static auto schemes = default_port_list{{
                                                {"ws"sv, static_cast<std::uint16_t>(80)},
                                                {"wss"sv, static_cast<std::uint16_t>(443)},
                                            }};
-
-constexpr static auto scheme_less(
-    const default_port_list::value_type &special_scheme,
-    std::string_view scheme) {
-  return special_scheme.first < scheme;
-};
 }  // namespace details
 
 /// \param scheme
 /// \returns
-inline auto is_special(std::string_view scheme) noexcept {
-  auto it = std::lower_bound(cbegin(details::schemes), cend(details::schemes), scheme, details::scheme_less);
-  return ((it != end(details::schemes)) && !(scheme < it->first));
+constexpr inline auto is_special(std::string_view scheme) noexcept {
+  constexpr auto less = [] (const auto &special_scheme, auto scheme) {
+    return special_scheme.first < scheme;
+  };
+
+  if (scheme.back() == ':') {
+    scheme.remove_suffix(1);
+  }
+  auto first = std::cbegin(details::schemes), last = std::cend(details::schemes);
+  auto it = std::lower_bound(first, last, scheme, less);
+  return ((it != last) && !(scheme < it->first));
 }
 
 /// \param scheme
 /// \returns
-inline auto default_port(std::string_view scheme) noexcept {
+constexpr inline auto default_port(std::string_view scheme) noexcept {
+  constexpr auto less = [] (const auto &special_scheme, auto scheme) {
+    return special_scheme.first < scheme;
+  };
+
   if (scheme.back() == ':') {
     scheme.remove_suffix(1);
   }
-  auto it = std::lower_bound(cbegin(details::schemes), cend(details::schemes), scheme, details::scheme_less);
-  return ((it != end(details::schemes)) && !(scheme < it->first)) ? it->second : std::nullopt;
+  auto first = std::cbegin(details::schemes), last = std::cend(details::schemes);
+  auto it = std::lower_bound(first, last, scheme, less);
+  return ((it != last) && !(scheme < it->first)) ? it->second : std::nullopt;
 }
 }  // namespace v1
 }  // namespace skyr

--- a/include/skyr/v1/url.hpp
+++ b/include/skyr/v1/url.hpp
@@ -219,6 +219,11 @@ class url {
   /// \returns The [URL origin](https://url.spec.whatwg.org/#origin)
   [[nodiscard]] auto origin() const -> string_type;
 
+  /// The URL scheme
+  [[nodiscard]] auto scheme() const -> string_type {
+    return url_.scheme;
+  }
+
   /// The URL scheme + `":"`
   ///
   /// \returns The [URL protocol](https://url.spec.whatwg.org/#dom-url-protocol)

--- a/tests/url/url_tests.cpp
+++ b/tests/url/url_tests.cpp
@@ -440,6 +440,12 @@ TEST_CASE("url_tests", "[url]") {
     CHECK_FALSE(port);
   }
 
+  SECTION("http_default_port_is_80_using_protocol") {
+    auto port = skyr::url::default_port("http:");
+    REQUIRE(port);
+    CHECK(80 == port.value());
+  }
+
   SECTION("about_blank") {
     auto instance = skyr::url("about:blank");
     CHECK("about:" == instance.protocol());


### PR DESCRIPTION
This is a fix for the issue reported in #135 

I also added an accessor for "url::scheme()"