### PR TITLE
Added support for clang with GNU stdlib (relevant on Ubuntu 18.04)

### DIFF
--- a/src/v1/CMakeLists.txt
+++ b/src/v1/CMakeLists.txt
@@ -95,6 +95,7 @@ set(gnu $<CXX_COMPILER_ID:GNU>)
 set(clang $<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>)
 set(libcxx $<AND:${clang},$<BOOL:${skyr_BUILD_WITH_LLVM_LIBCXX}>>)
 set(msvc $<CXX_COMPILER_ID:MSVC>)
+set(clang_with_gnu_stdlib $<AND:$<CXX_COMPILER_ID:Clang>,$<NOT:$<BOOL:${WIN32}>>,$<NOT:$<BOOL:${skyr_BUILD_WITH_LLVM_LIBCXX}>>>)
 
 target_compile_definitions(
         skyr-url-v1
@@ -161,6 +162,7 @@ if (skyr_ENABLE_FILESYSTEM_FUNCTIONS)
             INTERFACE
             skyr-url-v1
             $<${gnu}:"stdc++fs">
+            $<${clang_with_gnu_stdlib}:"stdc++fs">
     )
 
     target_include_directories(

--- a/src/v2/CMakeLists.txt
+++ b/src/v2/CMakeLists.txt
@@ -84,6 +84,7 @@ set(gnu $<CXX_COMPILER_ID:GNU>)
 set(clang $<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>)
 set(libcxx $<AND:${clang},$<BOOL:${skyr_BUILD_WITH_LLVM_LIBCXX}>>)
 set(msvc $<CXX_COMPILER_ID:MSVC>)
+set(clang_with_gnu_stdlib $<AND:$<CXX_COMPILER_ID:Clang>,$<NOT:$<BOOL:${WIN32}>>,$<NOT:$<BOOL:${skyr_BUILD_WITH_LLVM_LIBCXX}>>>)
 
 #target_compile_definitions(
 #        skyr-url-v2
@@ -149,6 +150,7 @@ if (skyr_ENABLE_FILESYSTEM_FUNCTIONS)
             INTERFACE
             skyr-url-v2
             $<${gnu}:"stdc++fs">
+            $<${clang_with_gnu_stdlib}:"stdc++fs">
     )
 
     target_include_directories(


### PR DESCRIPTION
This PR adds support for using clang with GNU stdlib on older versions of stdlib where its required to pass `stdc++fs` to the linker.

**NOTE:** In the cmake check for `clang_with_gnu_stdlib`, there is a generator expression checking `$<NOT:$<BOOL:${WIN32}>>`. This is not exactly what I would like to have there. Better would be a check for Linux, but I did not find a nice way to put that into a generator expression. Maybe `UNIX` would do, but the fix is also not required on Apple.

Closes #152