### PR TITLE
Switched to Catch2 v3

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ function(skyr_create_test file_name output_dir test_name version)
             ${test}
             PRIVATE
             skyr-url-${version}
-            Catch2::Catch2
+            Catch2::Catch2WithMain
             fmt::fmt
     )
     set_target_properties(

--- a/tests/v1/containers/static_vector_tests.cpp
+++ b/tests/v1/containers/static_vector_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <memory>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/containers/static_vector.hpp>
 
 

--- a/tests/v1/domain/domain_tests.cpp
+++ b/tests/v1/domain/domain_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <string>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/domain/domain.hpp>
 #include <skyr/v1/domain/errors.hpp>
 

--- a/tests/v1/domain/idna_table_tests.cpp
+++ b/tests/v1/domain/idna_table_tests.cpp
@@ -4,7 +4,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/domain/idna.hpp>
 
 

--- a/tests/v1/domain/punycode_tests.cpp
+++ b/tests/v1/domain/punycode_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <string>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/domain/punycode.hpp>
 
 

--- a/tests/v1/filesystem/filesystem_path_tests.cpp
+++ b/tests/v1/filesystem/filesystem_path_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/url.hpp>
 #include <skyr/v1/filesystem/path.hpp>
 

--- a/tests/v1/json/json_query_tests.cpp
+++ b/tests/v1/json/json_query_tests.cpp
@@ -5,7 +5,7 @@
 
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <vector>
 #include <skyr/v1/json/json.hpp>
 

--- a/tests/v1/network/ipv4_address_tests.cpp
+++ b/tests/v1/network/ipv4_address_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/network/ipv4_address.hpp>
 
 TEST_CASE("ipv4 addresses", "[ipv4]") {

--- a/tests/v1/network/ipv6_address_tests.cpp
+++ b/tests/v1/network/ipv6_address_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/network/ipv6_address.hpp>
 
 TEST_CASE("ipv6_address_tests", "[ipv6]") {

--- a/tests/v1/percent_encoding/percent_decoding_tests.cpp
+++ b/tests/v1/percent_encoding/percent_decoding_tests.cpp
@@ -4,7 +4,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 #include <skyr/v1/percent_encoding/percent_decode.hpp>

--- a/tests/v1/percent_encoding/percent_encoding_tests.cpp
+++ b/tests/v1/percent_encoding/percent_encoding_tests.cpp
@@ -4,7 +4,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 #include <skyr/v1/percent_encoding/percent_encode.hpp>

--- a/tests/v1/unicode/byte_conversion_tests.cpp
+++ b/tests/v1/unicode/byte_conversion_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <string>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/unicode/details/to_u8.hpp>
 
 TEST_CASE("weird_01", "byte_conversion_tests") {

--- a/tests/v1/unicode/unicode_code_point_tests.cpp
+++ b/tests/v1/unicode/unicode_code_point_tests.cpp
@@ -6,7 +6,7 @@
 #include <iterator>
 #include <string_view>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/unicode/code_point.hpp>
 
 

--- a/tests/v1/unicode/unicode_range_tests.cpp
+++ b/tests/v1/unicode/unicode_range_tests.cpp
@@ -6,7 +6,7 @@
 #include <iterator>
 #include <string_view>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/unicode/ranges/transforms/u16_transform.hpp>
 #include <skyr/v1/unicode/ranges/transforms/u32_transform.hpp>
 #include <skyr/v1/unicode/ranges/transforms/u8_transform.hpp>

--- a/tests/v1/unicode/unicode_tests.cpp
+++ b/tests/v1/unicode/unicode_tests.cpp
@@ -4,7 +4,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/unicode/ranges/transforms/u16_transform.hpp>
 #include <skyr/v1/unicode/ranges/transforms/u32_transform.hpp>
 #include <skyr/v1/unicode/ranges/transforms/u8_transform.hpp>

--- a/tests/v1/url/parse_host_tests.cpp
+++ b/tests/v1/url/parse_host_tests.cpp
@@ -6,7 +6,7 @@
 #include <string_view>
 #include <variant>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/core/host.hpp>
 
 TEST_CASE("parse_host_tests", "url.parse_host") {

--- a/tests/v1/url/url_literal_tests.cpp
+++ b/tests/v1/url/url_literal_tests.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <memory>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/url.hpp>
 
 using namespace skyr::literals;

--- a/tests/v1/url/url_parse_tests.cpp
+++ b/tests/v1/url/url_parse_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/core/parse.hpp>
 #include <skyr/v1/core/serialize.hpp>
 

--- a/tests/v1/url/url_search_parameters_tests.cpp
+++ b/tests/v1/url/url_search_parameters_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/url.hpp>
 #include <skyr/v1/url_search_parameters.hpp>
 

--- a/tests/v1/url/url_serialize_tests.cpp
+++ b/tests/v1/url/url_serialize_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/core/parse.hpp>
 #include <skyr/v1/core/serialize.hpp>
 

--- a/tests/v1/url/url_setter_tests.cpp
+++ b/tests/v1/url/url_setter_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/url.hpp>
 
 TEST_CASE("url_setter_tests", "[url]") {

--- a/tests/v1/url/url_tests.cpp
+++ b/tests/v1/url/url_tests.cpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <memory>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/url.hpp>
 
 TEST_CASE("url_tests", "[url]") {

--- a/tests/v1/url/url_tests_with_exceptions.cpp
+++ b/tests/v1/url/url_tests_with_exceptions.cpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <memory>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/url.hpp>
 
 TEST_CASE("url_tests", "[url]") {

--- a/tests/v1/url/url_vector_tests.cpp
+++ b/tests/v1/url/url_vector_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <vector>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/url.hpp>
 
 TEST_CASE("url_vector_tests", "[url]") {

--- a/tests/v2/containers/static_vector_tests.cpp
+++ b/tests/v2/containers/static_vector_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <memory>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/containers/static_vector.hpp>
 
 

--- a/tests/v2/core/parse_host_tests.cpp
+++ b/tests/v2/core/parse_host_tests.cpp
@@ -6,7 +6,7 @@
 #include <string_view>
 #include <variant>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/core/host.hpp>
 
 TEST_CASE("parse_host_tests", "url.parse_host") {

--- a/tests/v2/core/parse_path_tests.cpp
+++ b/tests/v2/core/parse_path_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/core/parse_path.hpp>
 
 TEST_CASE("path_parsing_example_tests", "[parse]") {

--- a/tests/v2/core/parse_query_tests.cpp
+++ b/tests/v2/core/parse_query_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/core/parse_query.hpp>
 
 TEST_CASE("query_parsing_example_tests", "[parse]") {

--- a/tests/v2/core/url_parse_tests.cpp
+++ b/tests/v2/core/url_parse_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/core/parse.hpp>
 #include <skyr/v2/core/serialize.hpp>
 

--- a/tests/v2/core/url_serialize_tests.cpp
+++ b/tests/v2/core/url_serialize_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/core/parse.hpp>
 #include <skyr/v2/core/serialize.hpp>
 

--- a/tests/v2/domain/domain_tests.cpp
+++ b/tests/v2/domain/domain_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <string>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/domain/domain.hpp>
 #include <skyr/v2/domain/errors.hpp>
 

--- a/tests/v2/domain/idna_table_tests.cpp
+++ b/tests/v2/domain/idna_table_tests.cpp
@@ -4,7 +4,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/domain/idna.hpp>
 
 

--- a/tests/v2/domain/punycode_tests.cpp
+++ b/tests/v2/domain/punycode_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <string>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/domain/punycode.hpp>
 
 

--- a/tests/v2/filesystem/filesystem_path_tests.cpp
+++ b/tests/v2/filesystem/filesystem_path_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/url.hpp>
 #include <skyr/v2/filesystem/path.hpp>
 

--- a/tests/v2/json/json_query_tests.cpp
+++ b/tests/v2/json/json_query_tests.cpp
@@ -5,7 +5,7 @@
 
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <vector>
 #include <skyr/v2/json/json.hpp>
 

--- a/tests/v2/network/ipv4_address_tests.cpp
+++ b/tests/v2/network/ipv4_address_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/network/ipv4_address.hpp>
 
 TEST_CASE("ipv4 addresses", "[ipv4]") {

--- a/tests/v2/network/ipv6_address_tests.cpp
+++ b/tests/v2/network/ipv6_address_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/network/ipv6_address.hpp>
 
 TEST_CASE("ipv6_address_tests", "[ipv6]") {

--- a/tests/v2/percent_encoding/percent_decoding_tests.cpp
+++ b/tests/v2/percent_encoding/percent_decoding_tests.cpp
@@ -4,7 +4,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 #include <skyr/v2/percent_encoding/percent_decode.hpp>

--- a/tests/v2/percent_encoding/percent_encoding_tests.cpp
+++ b/tests/v2/percent_encoding/percent_encoding_tests.cpp
@@ -4,7 +4,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 #include <skyr/v2/percent_encoding/percent_encoded_char.hpp>

--- a/tests/v2/unicode/byte_conversion_tests.cpp
+++ b/tests/v2/unicode/byte_conversion_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <string>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/unicode/details/to_u8.hpp>
 
 TEST_CASE("weird_01", "byte_conversion_tests") {

--- a/tests/v2/unicode/unicode_code_point_tests.cpp
+++ b/tests/v2/unicode/unicode_code_point_tests.cpp
@@ -6,7 +6,7 @@
 #include <iterator>
 #include <string_view>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/unicode/code_point.hpp>
 
 

--- a/tests/v2/unicode/unicode_range_tests.cpp
+++ b/tests/v2/unicode/unicode_range_tests.cpp
@@ -6,7 +6,7 @@
 #include <iterator>
 #include <string_view>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/unicode/ranges/transforms/u16_transform.hpp>
 #include <skyr/v2/unicode/ranges/transforms/u32_transform.hpp>
 #include <skyr/v2/unicode/ranges/transforms/u8_transform.hpp>

--- a/tests/v2/unicode/unicode_tests.cpp
+++ b/tests/v2/unicode/unicode_tests.cpp
@@ -4,7 +4,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/unicode/ranges/transforms/u16_transform.hpp>
 #include <skyr/v2/unicode/ranges/transforms/u32_transform.hpp>
 #include <skyr/v2/unicode/ranges/transforms/u8_transform.hpp>

--- a/tests/v2/url/url_literal_tests.cpp
+++ b/tests/v2/url/url_literal_tests.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <memory>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/url.hpp>
 
 using namespace skyr::literals;

--- a/tests/v2/url/url_search_parameters_tests.cpp
+++ b/tests/v2/url/url_search_parameters_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v1/url.hpp>
 #include <skyr/v1/url_search_parameters.hpp>
 

--- a/tests/v2/url/url_setter_tests.cpp
+++ b/tests/v2/url/url_setter_tests.cpp
@@ -4,7 +4,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/url.hpp>
 
 TEST_CASE("url_setter_tests", "[url]") {

--- a/tests/v2/url/url_tests.cpp
+++ b/tests/v2/url/url_tests.cpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <memory>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/url.hpp>
 
 TEST_CASE("url_tests", "[url]") {

--- a/tests/v2/url/url_tests_with_exceptions.cpp
+++ b/tests/v2/url/url_tests_with_exceptions.cpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <memory>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/url.hpp>
 
 TEST_CASE("url_tests", "[url]") {

--- a/tests/v2/url/url_vector_tests.cpp
+++ b/tests/v2/url/url_vector_tests.cpp
@@ -5,7 +5,7 @@
 
 #include <vector>
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <skyr/v2/url.hpp>
 
 TEST_CASE("url_vector_tests", "[url]") {


### PR DESCRIPTION
Added support for Catch2 v3. This may not be commonly relevant yet, but can be helpful for projects that switched to v3 already.